### PR TITLE
Interfacing Python and Java

### DIFF
--- a/src/main/java/annotatorstub/main/PythonApiMain.java
+++ b/src/main/java/annotatorstub/main/PythonApiMain.java
@@ -1,0 +1,35 @@
+package annotatorstub.main;
+
+import annotatorstub.utils.PythonApiInterface;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+
+public class PythonApiMain {
+
+    public static void main(String[] args) throws IOException {
+        PythonApiInterface classifierApi = new PythonApiInterface(5000);
+
+        try {
+            classifierApi.startPythonServer();
+            ArrayList<Double> features = new ArrayList<Double>(Arrays.asList(1.0, 5.0, 1023.2));
+
+            boolean result;
+
+            result = classifierApi.binClassifyFlask(features);
+            System.out.println("Result 1: " + result);          // Should print the sum of features
+
+            classifierApi.stopPythonServer();
+
+            result = classifierApi.binClassifyFlask(features);  // Should throw an error because server is killed
+            System.out.println("Result 2: " + result);
+        } catch (Exception e) {
+            classifierApi.stopPythonServer();
+            e.printStackTrace();
+        }
+
+
+    }
+}

--- a/src/main/java/annotatorstub/utils/PythonApiInterface.java
+++ b/src/main/java/annotatorstub/utils/PythonApiInterface.java
@@ -1,0 +1,96 @@
+package annotatorstub.utils;
+
+import java.io.*;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.List;
+
+
+public class PythonApiInterface {
+
+    private final String API_ADDRESS    = "http://localhost";
+    private final String API_ENDPOINT   = "predict";
+    private final String SEPARATOR      = ",";
+    private Integer API_PORT;
+    private Process serverProcess;
+
+    public PythonApiInterface(Integer port) {
+        API_PORT = port;
+    }
+
+    /**
+     * Start the Python server for serving predictions over HTTP.
+     */
+    public void startPythonServer() throws IOException, InterruptedException {
+        String line;
+        serverProcess = Runtime.getRuntime().exec("python src/main/python/server.py");
+
+
+        /*BufferedReader bri = new BufferedReader(new InputStreamReader(serverProcess.getInputStream()));
+        BufferedReader bre = new BufferedReader(new InputStreamReader(serverProcess.getErrorStream()));
+        while ((line = bri.readLine()) != null) {
+            System.out.println(line);
+        }
+        bri.close();
+        while ((line = bre.readLine()) != null) {
+            System.out.println(line);
+        }
+        bre.close();*/
+
+        Thread.sleep(2000);     // TODO hacky way to make sure the server is started...
+    }
+
+    /**
+     * Stop the Python server.
+     */
+    public void stopPythonServer() {
+        serverProcess.destroy();
+    }
+
+    private String makeSeparatedString(List<Double> features) {
+        String separatedString = "";
+        Integer index = 0;
+        for(Double f : features) {
+            separatedString += f.toString();
+            if(index < features.size()-1) {
+                separatedString += SEPARATOR;
+            }
+            index++;
+        }
+
+        return separatedString;
+    }
+
+    /**
+     * Classify given list of features by calling the Python API.
+     * @see http://stackoverflow.com/questions/1359689/how-to-send-http-request-in-java
+     */
+    public boolean binClassifyFlask(List<Double> features) throws IOException {
+        String urlParameters = "?features_string=" + makeSeparatedString(features);
+        String queryUrl = API_ADDRESS + ":" + API_PORT + "/" + API_ENDPOINT;
+
+        // Set up connection and send the request
+        URL url = new URL(queryUrl + urlParameters);
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setRequestMethod("GET");
+        connection.setUseCaches(false);
+        connection.setDoOutput(true);
+
+        // Read response
+        InputStream is = connection.getInputStream();
+        BufferedReader rd = new BufferedReader(new InputStreamReader(is));
+        StringBuilder response = new StringBuilder();
+        String line;
+        while((line = rd.readLine()) != null) {
+            response.append(line);
+            response.append('\r');
+        }
+        rd.close();
+
+
+        String responseString = response.toString();
+        System.out.println(responseString);
+        return Boolean.parseBoolean(responseString);
+    }
+
+}

--- a/src/main/python/server.py
+++ b/src/main/python/server.py
@@ -1,0 +1,21 @@
+from flask import Flask, request
+app = Flask(__name__)
+
+#app.config['DEBUG'] = True
+SEPARATOR = ","
+
+@app.route("/")
+def hello():
+    return "Move along, nothing to see here."
+
+@app.route("/predict", methods=['GET', 'POST'])
+def predict():
+	features_string = request.args.get("features_string")
+	features = [float(x) for x in features_string.split(SEPARATOR)]
+
+	s = sum(features) # TODO this is where the magic (classification) needs to happen
+
+	return(str(s))
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
See `annotatorstub.main.PythonApiMain.java` for example usage.

`PythonApiInterface` is the class that handles starting the Python server (`src/main/python/server.py`), sending requests (and returning the appropriate output) and stopping the server.

Note that you need to explicitly stop the Python server with `PythonApiInterface.stopPythonServer()`, otherwise the process will linger around and you'll need to go manually kill it. This means you need to catch any exception that `PythonApiInterface.binClassifyFlask()` might throw, otherwise the process won't be killed by Java.
